### PR TITLE
feat: make `UpdateSearchText` thread-safe and add `CancellationToken`-based suggestions cancellation

### DIFF
--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/SearchWebPage.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,7 +17,11 @@ internal sealed partial class SearchWebPage : DynamicListPage
     private readonly IListItem _openHomePageItem;
     private IListItem[] _items = [];
     private IListItem[] _suggestionItems = [];
-    private int _updateEpoch;
+    private int _lastUpdateSearchTextEpoch;
+    private readonly Lock _swapSuggestionsCancellationSourceLock = new();
+    private readonly Lock _renderLock = new();
+    private readonly Lock _updateSuggestionLock = new();
+    private CancellationTokenSource? _previousSuggestionsCancellationSource;
 
     public SearchWebPage(WebSearchShortcutDataEntry shortcut)
     {
@@ -29,48 +34,114 @@ internal sealed partial class SearchWebPage : DynamicListPage
             Title = StringFormatter.Format(Resources.OpenHomePage_TitleTemplate, new() { ["engine"] = Name })
         };
 
-        _updateEpoch = 0;
-
         _items = [_openHomePageItem];
     }
 
-    public override IListItem[] GetItems() => _items;
+    public override IListItem[] GetItems() => Volatile.Read(ref _items);
 
     public override async void UpdateSearchText(string oldSearch, string newSearch)
     {
-        var capturedEpoch = Interlocked.Increment(ref _updateEpoch);
+        int currentEpoch = Interlocked.Increment(ref _lastUpdateSearchTextEpoch);
 
-        if (string.IsNullOrEmpty(newSearch))
+        bool shouldOpenHomePage = string.IsNullOrEmpty(newSearch);
+        bool shouldFetchSuggestions = !shouldOpenHomePage && !string.IsNullOrEmpty(_shortcut.SuggestionProvider);
+
+        CancellationTokenSource? currentCancellationSource = shouldFetchSuggestions ? new CancellationTokenSource() : null;
+        CancellationTokenSource? previousCancellationSource;
+
+        lock (_swapSuggestionsCancellationSourceLock)
         {
-            _suggestionItems = [];
+            if (currentEpoch != Volatile.Read(ref _lastUpdateSearchTextEpoch))
+            {
+                currentCancellationSource?.Dispose();
+                return;
+            }
 
-            RenderItems([_openHomePageItem]);
+            previousCancellationSource = Interlocked.Exchange(ref _previousSuggestionsCancellationSource, currentCancellationSource);
+        }
+
+        try
+        {
+            previousCancellationSource?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
+        if (shouldOpenHomePage)
+        {
+            UpdateSuggestionItems([], currentEpoch);
+
+            RenderItems([_openHomePageItem], currentEpoch);
 
             return;
         }
 
         var primaryItems = BuildPrimaryItems(newSearch);
+        var snapshotSuggestions = Volatile.Read(ref _suggestionItems);
 
-        RenderItems([.. primaryItems, .. _suggestionItems]);
+        RenderItems([.. primaryItems, .. snapshotSuggestions], currentEpoch);
 
-        if (string.IsNullOrEmpty(_shortcut.SuggestionProvider))
+        if (!shouldFetchSuggestions)
             return;
 
-        var suggestionItems = await GetSuggestionItemsAsync(newSearch);
-
-        if (capturedEpoch != _updateEpoch)
+        IListItem[] suggestionItems;
+        try
+        {
+            suggestionItems = await FetchSuggestionItemsAsync(newSearch, currentCancellationSource!.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
             return;
+        }
+        catch (Exception ex)
+        {
+            ExtensionHost.LogMessage("Suggestions fetch failed: " + ex.ToString());
 
-        _suggestionItems = suggestionItems;
+            return;
+        }
+        finally
+        {
+            Interlocked.CompareExchange(ref _previousSuggestionsCancellationSource, null, currentCancellationSource);
 
-        RenderItems([.. primaryItems, .. _suggestionItems]);
+            currentCancellationSource!.Dispose();
+        }
+
+        if (currentEpoch != Volatile.Read(ref _lastUpdateSearchTextEpoch)) return;
+
+        UpdateSuggestionItems(suggestionItems, currentEpoch);
+
+        RenderItems([.. primaryItems, .. suggestionItems], currentEpoch);
     }
 
-    private void RenderItems(IListItem[] items)
+    private void RenderItems(IListItem[] items, int currentUpdateSearchTextEpoch)
     {
-        _items = items;
+        if (currentUpdateSearchTextEpoch != Volatile.Read(ref _lastUpdateSearchTextEpoch))
+            return;
 
-        RaiseItemsChanged(_items.Length);
+        lock (_renderLock)
+        {
+            if (currentUpdateSearchTextEpoch != Volatile.Read(ref _lastUpdateSearchTextEpoch))
+                return;
+
+            Volatile.Write(ref _items, items);
+        }
+
+        RaiseItemsChanged(items.Length);
+    }
+
+    private void UpdateSuggestionItems(IListItem[] suggestionItems, int currentUpdateSearchTextEpoch)
+    {
+        if (currentUpdateSearchTextEpoch != Volatile.Read(ref _lastUpdateSearchTextEpoch))
+            return;
+
+        lock (_updateSuggestionLock)
+        {
+            if (currentUpdateSearchTextEpoch != Volatile.Read(ref _lastUpdateSearchTextEpoch))
+                return;
+
+            Volatile.Write(ref _suggestionItems, suggestionItems);
+        }
     }
 
     private ListItem[] BuildPrimaryItems(string searchText)
@@ -86,11 +157,11 @@ internal sealed partial class SearchWebPage : DynamicListPage
         ];
     }
 
-    private async Task<ListItem[]> GetSuggestionItemsAsync(string searchText)
+    private async Task<ListItem[]> FetchSuggestionItemsAsync(string searchText, CancellationToken cancellationToken)
     {
         var suggestions = await SuggestionsRegistry
             .Get(_shortcut.SuggestionProvider!)
-            .GetSuggestionsAsync(searchText)
+            .GetSuggestionsAsync(searchText, cancellationToken)
             .ConfigureAwait(false);
 
         return

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Suggestion.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Suggestion.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using WebSearchShortcut.SuggestionsProviders;
 
@@ -9,7 +10,7 @@ namespace WebSearchShortcut;
 internal interface ISuggestionsProvider
 {
     string Name { get; }
-    Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query);
+    Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query, CancellationToken cancellationToken = default);
 }
 
 internal sealed record Suggestion(string Title, string? Description = null);

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/SuggestionsProviders/Bing.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/SuggestionsProviders/Bing.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using WebSearchShortcut.Properties;
@@ -15,18 +16,18 @@ internal sealed class Bing : ISuggestionsProvider
 
     private HttpClient Http { get; } = new HttpClient();
 
-    public async Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query)
+    public async Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query, CancellationToken cancellationToken = default)
     {
         try
         {
             const string api = "https://api.bing.com/qsonhs.aspx?q=";
 
             await using var resultStream = await Http
-                .GetStreamAsync(api + Uri.EscapeDataString(query))
+                .GetStreamAsync(api + Uri.EscapeDataString(query), cancellationToken)
                 .ConfigureAwait(false);
 
             using var json = await JsonDocument
-                .ParseAsync(resultStream)
+                .ParseAsync(resultStream, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             var root = json.RootElement.GetProperty("AS");

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/SuggestionsProviders/CanIUse.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/SuggestionsProviders/CanIUse.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using WebSearchShortcut.Properties;
@@ -15,18 +16,18 @@ internal sealed class CanIUse : ISuggestionsProvider
 
     private HttpClient Http { get; } = new HttpClient();
 
-    public async Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query)
+    public async Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query, CancellationToken cancellationToken = default)
     {
         try
         {
             const string api = "https://caniuse.com/process/query.php?search=";
 
             await using var resultStream = await Http
-                .GetStreamAsync(api + Uri.EscapeDataString(query))
+                .GetStreamAsync(api + Uri.EscapeDataString(query), cancellationToken)
                 .ConfigureAwait(false);
 
             using var json = await JsonDocument
-                .ParseAsync(resultStream)
+                .ParseAsync(resultStream, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             var featureIds = json

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/SuggestionsProviders/DuckDuckGo.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/SuggestionsProviders/DuckDuckGo.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using WebSearchShortcut.Properties;
@@ -15,18 +16,18 @@ internal sealed class DuckDuckGo : ISuggestionsProvider
 
     private HttpClient Http { get; } = new HttpClient();
 
-    public async Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query)
+    public async Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query, CancellationToken cancellationToken = default)
     {
         try
         {
             const string api = "https://duckduckgo.com/ac/?q=";
 
             await using var resultStream = await Http
-                .GetStreamAsync(api + Uri.EscapeDataString(query))
+                .GetStreamAsync(api + Uri.EscapeDataString(query), cancellationToken)
                 .ConfigureAwait(false);
 
             using var json = await JsonDocument
-                .ParseAsync(resultStream)
+                .ParseAsync(resultStream, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             var results = json.RootElement;

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/SuggestionsProviders/Google.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/SuggestionsProviders/Google.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using WebSearchShortcut.Properties;
@@ -15,18 +16,18 @@ internal sealed class Google : ISuggestionsProvider
 
     private HttpClient Http { get; } = new HttpClient();
 
-    public async Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query)
+    public async Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query, CancellationToken cancellationToken = default)
     {
         try
         {
             const string api = "https://www.google.com/complete/search?output=chrome&q=";
 
             await using var resultStream = await Http
-                .GetStreamAsync(api + Uri.EscapeDataString(query))
+                .GetStreamAsync(api + Uri.EscapeDataString(query), cancellationToken)
                 .ConfigureAwait(false);
 
             using var json = await JsonDocument
-                .ParseAsync(resultStream)
+                .ParseAsync(resultStream, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             var results = json.RootElement.EnumerateArray().ElementAt(1);

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/SuggestionsProviders/Npm.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/SuggestionsProviders/Npm.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using WebSearchShortcut.Properties;
@@ -15,18 +16,18 @@ internal sealed class Npm : ISuggestionsProvider
 
     private HttpClient Http { get; } = new HttpClient();
 
-    public async Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query)
+    public async Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query, CancellationToken cancellationToken = default)
     {
         try
         {
             const string api = "https://www.npmjs.com/search/suggestions?q=";
 
             await using var resultStream = await Http
-                .GetStreamAsync(api + Uri.EscapeDataString(query))
+                .GetStreamAsync(api + Uri.EscapeDataString(query), cancellationToken)
                 .ConfigureAwait(false);
 
             using var json = await JsonDocument
-                .ParseAsync(resultStream)
+                .ParseAsync(resultStream, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             var results = json.RootElement.EnumerateArray();

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/SuggestionsProviders/Wikipedia.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/SuggestionsProviders/Wikipedia.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using WebSearchShortcut.Properties;
@@ -15,18 +16,18 @@ internal sealed class Wikipedia : ISuggestionsProvider
 
     private HttpClient Http { get; } = new HttpClient();
 
-    public async Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query)
+    public async Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query, CancellationToken cancellationToken = default)
     {
         try
         {
             const string api = "https://api.wikimedia.org/core/v1/wikipedia/en/search/title?q=";
 
             await using var resultStream = await Http
-                .GetStreamAsync(api + Uri.EscapeDataString(query))
+                .GetStreamAsync(api + Uri.EscapeDataString(query), cancellationToken)
                 .ConfigureAwait(false);
 
             using var json = await JsonDocument
-                .ParseAsync(resultStream)
+                .ParseAsync(resultStream, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             var results = json.RootElement.GetProperty("pages");

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/SuggestionsProviders/YouTube.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/SuggestionsProviders/YouTube.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using WebSearchShortcut.Properties;
@@ -16,14 +17,14 @@ internal sealed class YouTube : ISuggestionsProvider
 
     private HttpClient Http { get; } = new HttpClient();
 
-    public async Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query)
+    public async Task<IReadOnlyList<Suggestion>> GetSuggestionsAsync(string query, CancellationToken cancellationToken = default)
     {
         try
         {
             const string api = "https://suggestqueries-clients6.youtube.com/complete/search?ds=yt&client=youtube&gs_ri=youtube&q=";
 
             var result = await Http
-                .GetStringAsync(api + Uri.EscapeDataString(query))
+                .GetStringAsync(api + Uri.EscapeDataString(query), cancellationToken)
                 .ConfigureAwait(false);
 
             var match = Regex.Match(result, @"window\.google\.ac\.h\((.*)\)$");


### PR DESCRIPTION
**Background**

The Command Palette host invokes `UpdateSearchText` concurrently on multiple background threads. This keeps the UI responsive, but it also means the data flow and rendering must be thread-safe. Although humans type slowly and most `SuggestionProvider`s hit the network (making races less likely), we cannot guarantee that:

* The timing between user input and the host calling `UpdateSearchText` won’t cause closely spaced concurrent invocations;
* There won’t be ultra-fast `SuggestionProvider`s in the future.

This can lead to:

* **Stale requests overwriting fresh results** (race condition).
* **Cancellation not taking effect**, with old requests silently continuing in the background and consuming resources.

**What’s changed**

**Thread safety**

* Use `Volatile.Read/Write` to ensure memory visibility for `_items` / `_suggestionItems`.
* Protect writes with fine-grained locks (render lock and suggestion lock), and invoke `RaiseItemsChanged(...)` outside the lock to avoid handlers blocking the critical section.

**Robust cancellation**

* For each input change, create the **latest** `CancellationTokenSource`; replace the previous one **inside** the lock via `Interlocked.Exchange`, cancel the old CTS **outside** the lock, and dispose it in `finally` to avoid lingering work or double-dispose.
* `FetchSuggestionItemsAsync(..., CancellationToken)` passes the token down to the provider so I/O can halt immediately.

**Impact**

External behavior and UX remain **unchanged**, but:

* Fast typing no longer results in outdated suggestions overwriting the latest results.
* Network requests are **immediately canceled** when input changes, reducing latency and resource usage.

**Files of interest**

* `SearchWebPage.cs` (CTS swapping, locks, `Volatile`, error handling)
* `Suggestion.cs` (supports `CancellationToken`)

**Notes**

With this version, even if multiple threads enter `UpdateSearchText` at the same time, state consistency and correct rendering are preserved.