### PR TITLE
add fallback commands

### DIFF
--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Commands/SearchWebCommand.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Commands/SearchWebCommand.cs
@@ -7,16 +7,22 @@ namespace WebSearchShortcut.Commands;
 
 internal sealed partial class SearchWebCommand : InvokableCommand
 {
-    private readonly string _query;
+    public string Query { get; internal set; } = string.Empty;
     private readonly WebSearchShortcutDataEntry _shortcut;
     private readonly BrowserExecutionInfo _browserInfo;
     // private readonly SettingsManager _settingsManager;
+
+    public new string Id
+    {
+        get => base.Id;
+        set => base.Id = value;
+    }
 
     public SearchWebCommand(WebSearchShortcutDataEntry shortcut, string query)
     {
         Name = StringFormatter.Format(Resources.SearchQuery_NameTemplate, new() { ["engine"] = shortcut.Name, ["query"] = query });
         Icon = Icons.Search;
-        _query = query;
+        Query = query;
         _shortcut = shortcut;
         _browserInfo = new BrowserExecutionInfo(shortcut);
         // _settingsManager = settingsManager;
@@ -24,7 +30,7 @@ internal sealed partial class SearchWebCommand : InvokableCommand
 
     public override CommandResult Invoke()
     {
-        if (!ShellHelpers.OpenCommandInShell(_browserInfo.Path, _browserInfo.ArgumentsPattern, WebSearchShortcutDataEntry.GetSearchUrl(_shortcut, _query)))
+        if (!ShellHelpers.OpenCommandInShell(_browserInfo.Path, _browserInfo.ArgumentsPattern, WebSearchShortcutDataEntry.GetSearchUrl(_shortcut, Query)))
         {
             // TODO GH# 138 --> actually display feedback from the extension somewhere.
             return CommandResult.KeepOpen();

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/FallbackSearchWebItem.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/Pages/FallbackSearchWebItem.cs
@@ -1,0 +1,42 @@
+﻿using Windows.ApplicationModel;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using WebSearchShortcut.Commands;
+using WebSearchShortcut.Helpers;
+using WebSearchShortcut.Properties;
+using WebSearchShortcut.Services;
+
+namespace WebSearchShortcut;
+
+internal sealed partial class FallbackSearchWebItem : FallbackCommandItem
+{
+    private readonly SearchWebCommand _searchWebCommand;
+    private readonly WebSearchShortcutDataEntry _shortcut;
+
+    public FallbackSearchWebItem(WebSearchShortcutDataEntry shortcut)
+        : base(new SearchWebCommand(shortcut, string.Empty) { Id = $"{Package.Current.Id.FamilyName}!App!ID{shortcut.Name}.fallback" }, shortcut.Name)
+    {
+        _shortcut = shortcut;
+
+        _searchWebCommand = (SearchWebCommand)Command!;
+        _searchWebCommand.Name = string.Empty;
+
+        Title = string.Empty;
+        Subtitle = string.Empty;
+        Icon = IconService.GetIconInfo(shortcut);
+        MoreCommands = [new CommandContextItem(new OpenHomePageCommand(_shortcut))];
+    }
+
+    public override void UpdateQuery(string query)
+    {
+        bool isEmpty = string.IsNullOrWhiteSpace(query);
+
+        // Order matters: update command state before Title. (Verified 2025-08-21)
+        // Title may be derived from/overwritten by Command.Name.
+        // Set Command.Name before Title to avoid stale or inconsistent UI.
+        _searchWebCommand.Name = isEmpty ? string.Empty : StringFormatter.Format(Resources.SearchQuery_NameTemplate, new() { ["engine"] = _shortcut.Name, ["query"] = query });
+        _searchWebCommand.Query = query;
+
+        Title = isEmpty ? string.Empty : query;
+        Subtitle = isEmpty ? string.Empty : StringFormatter.Format(Resources.SearchQuery_SubtitleTemplate, new() { ["engine"] = _shortcut.Name, ["query"] = query });
+    }
+}

--- a/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutCommandsProvider.cs
+++ b/CmdPalWebSearchShortcut/WebSearchShortcut/WebSearchShortcutCommandsProvider.cs
@@ -19,6 +19,7 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
 {
     private readonly AddShortcutPage _addShortcutPage = new(null);
     private ICommandItem[] _topLevelCommands = [];
+    private IFallbackCommandItem[] _fallbackCommands = [];
     private Storage? _storage;
 
     public WebSearchShortcutCommandsProvider()
@@ -38,6 +39,8 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
 
         return _topLevelCommands;
     }
+
+    public override IFallbackCommandItem[] FallbackCommands() => _fallbackCommands;
 
     internal static string GetShortcutsJsonPath()
     {
@@ -92,6 +95,7 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
     private void ReloadCommands()
     {
         List<CommandItem> items = [new CommandItem(_addShortcutPage)];
+        List<FallbackCommandItem> fallbackItem = [];
 
         if (_storage is null)
         {
@@ -101,9 +105,11 @@ public partial class WebSearchShortcutCommandsProvider : CommandProvider
         if (_storage is not null)
         {
             items.AddRange(_storage.Data.Select(CreateCommandItem));
+            fallbackItem.AddRange(_storage.Data.Select(shortcut => new FallbackSearchWebItem(shortcut)));
         }
 
         _topLevelCommands = [.. items];
+        _fallbackCommands = [.. fallbackItem];
     }
 
     private void LoadShortcutFromFile()


### PR DESCRIPTION
## Summary

This PR creates a corresponding fallback command for each web search shortcut, allowing users to type directly on the Command Palette home page and search with the selected engine.

## Motivation

* Shorter launch path: no need to enter a specific engine page first; just type on the home page to search.


## Key Changes

* Add `FallbackSearchWebItem`: wraps `SearchWebCommand` and adds the "Open home page" command to `MoreCommands`.
* Behavioral parity: matches the existing SearchWebCommand and provides the "Open home page" action with the same title/subtitle format.

* Implement `FallbackCommands()` in `WebSearchShortcutCommandsProvider` and create one `FallbackSearchWebItem` per shortcut at load time.

## Known Limitations (important)
At this stage, we cannot change the Command Palette’s default of enabling fallback commands—there is no API to override it—so users with many shortcuts (for example, I have 200) must disable them one by one.


Because `shortcut.Name` is part of the command ID, duplicate names lead to coupling and collisions:

* Settings page may show two shortcuts, but their toggles (e.g., enable/disable fallback commands) are linked.
* The home page will show two fallback commands for the same name.
* Disabling one also disables the other, causing both to disappear from the home fallback list.

This matches what is described in pull #50. This PR provides the feature only and does not address ID collisions.

## Background

There is a reference implementation with independent IDs:
[https://github.com/Testudinidae/PowerToys-Run-WebSearchShortcut/tree/feature/fallback/id](https://github.com/Testudinidae/PowerToys-Run-WebSearchShortcut/tree/feature/fallback/id)

However, migrating from the no-id version to the id version has side effects documented in pull #50. Choosing between them is a significant decision. This PR keeps the current no-id approach; however, deferring the introduction of independent IDs will increase the associated technical debt.